### PR TITLE
Non recursive 

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,12 @@ func (m *model) loadFile() {
 	}
 
 	for _, s := range dir {
-		if !strings.HasPrefix(s.Name(), ".") {
-			files = append(files, s.Name())
+		fileName := s.Name()
+		if !strings.HasPrefix(fileName, ".") {
+			if s.IsDir() {
+				fileName = s.Name() + "/"
+			}
+			files = append(files, fileName)
 		}
 	}
 	m.files = files


### PR DESCRIPTION
#  Changes
### 1) Removed filepath.walkdir
- File path walkdir recursively walks the current directory and all other directories in the current path therefore making it unsuited to our current task . I opted to use os.ReadDir which only reads contents in the specified directory 
### 2) Fixed moving backwards and forwards
- In the case h filepath.Dir returns all but the last element of path, typically the path's directory for example, if the current path is /home/user/Desktop, pressing h will change the path to /home/user.  making us move a directory upwards.
- In the case L we are appending m.path to the path we want to go to e.g Desktop + yahtzee = Desktop/yahtzee
